### PR TITLE
Quartus.inc.tcl [BUGFIX]: catched exception when calling quartus_syn

### DIFF
--- a/build/Quartus.inc.tcl
+++ b/build/Quartus.inc.tcl
@@ -247,7 +247,9 @@ proc SynthesizeDesignSetup {synth_flags} {
 proc SynthesizeDesignRun {synth_flags} {
     PrintLabel "Synthesize"
 
-    execute_module -tool syn
+    if {[catch {execute_module -tool syn}]} {
+        execute_module -tool map
+    }
 }
 
 # -----------------------------------------------------------------------------

--- a/build/Quartus.inc.tcl
+++ b/build/Quartus.inc.tcl
@@ -52,6 +52,10 @@ proc EvalFile {FNAME OPT} {
             # VHDL file
             set_global_assignment -name VHDL_FILE $FNAME -hdl_version VHDL_2008 {*}$LIB_PARAM
             puts "INFO: Library $opt(LIBRARY): File added: $FNAME"
+        } elseif { $FEXT == ".v" } {
+            # Verilog file
+            set_global_assignment -name VERILOG_FILE $FNAME {*}$LIB_PARAM
+            puts "INFO: Library $opt(LIBRARY): File added: $FNAME"
         } elseif { $FEXT == ".sv" } {
             # System Verilog file
             set_global_assignment -name SYSTEMVERILOG_FILE $FNAME {*}$LIB_PARAM


### PR DESCRIPTION
The Quartus Prime Lite version does not support the quartus_syn command but uses quartus_map with the same arguments instead. The unusccessful call of quartus_syn produces error message even if catched by the catch shell command. Advise for how to disard this message is welcomed.