### PR TITLE
Vivado Block design support

### DIFF
--- a/build/Shared.tcl
+++ b/build/Shared.tcl
@@ -259,6 +259,19 @@ proc ofm_replace_modules_path {ENTITY_BASE} {
 
 # ------------------------ ApplyToComponent -----------------------------
 
+proc DeduceType {FNAME {TYPE ""}} {
+    # Backward compatibility
+    set type $TYPE
+    if {[file tail $FNAME] == "DevTree.tcl" && $TYPE == ""} {
+        set type "DEVTREE"
+    } elseif {[regexp ".xci$" $FNAME] && $TYPE == ""} {
+        set type "VIVADO_IP_XACT"
+    } elseif {[regexp ".bd$" $FNAME] && $TYPE == ""} {
+        set type "VIVADO_BD"
+    } 
+    return $type
+}
+
 # Apply Command To Module List
 proc ApplyToMods {MODULE COMMAND FILES {TYPE ""}} {
     upvar 1 $FILES FILES_VAR
@@ -276,13 +289,7 @@ proc ApplyToMods {MODULE COMMAND FILES {TYPE ""}} {
         set fname [SimplPath $fname]
 
         # Backward compatibility
-        set type $TYPE
-        if {[file tail $fname] == "DevTree.tcl" && $TYPE == ""} {
-            set type "DEVTREE"
-        } elseif {[regexp ".xci$" $fname] && $TYPE == ""} {
-            set type "VIVADO_IP_XACT"
-        }
-
+        set type [DeduceType $fname $TYPE]
         lappend params "TYPE" $type
 
         set f [concat $fname $params]

--- a/build/Vivado.inc.tcl
+++ b/build/Vivado.inc.tcl
@@ -129,6 +129,8 @@ proc SetupDesign {synth_flags} {
     foreach i $SYNTH_FLAGS(SETUP_FLAGS) {
         if { $i == "USE_XPM_LIBRARIES" } {
             set_property XPM_LIBRARIES {XPM_CDC XPM_MEMORY XPM_FIFO} [current_project]
+        } elseif { $i == "COMPILE_ORDER_AUTO" } {
+            set_property source_mgmt_mode All [current_project]
         }
         # TODO: Implement when needed
     }

--- a/build/Vivado.inc.tcl
+++ b/build/Vivado.inc.tcl
@@ -69,7 +69,13 @@ proc EvalFile {FNAME OPT} {
     } elseif {$opt(TYPE) == "VIVADO_IP_XACT"} {
         add_files -norecurse $FNAME
         puts "IP added: $FNAME"
+    } elseif {$opt(TYPE) == "VIVADO_BD"} {
+        add_files -norecurse $FNAME
+        puts "BD added: $FNAME"
+        generate_target all [get_files $FNAME] -force
+        upgrade_ip [get_ips *] -quiet
     }
+
 
     foreach {param_name param_value} $OPT {
         if {$param_name == "VIVADO_SET_PROPERTY"} {

--- a/build/Vivado.inc.tcl
+++ b/build/Vivado.inc.tcl
@@ -128,7 +128,7 @@ proc SetupDesign {synth_flags} {
     # Apply user settings
     foreach i $SYNTH_FLAGS(SETUP_FLAGS) {
         if { $i == "USE_XPM_LIBRARIES" } {
-            set_property XPM_LIBRARIES {XPM_CDC XPM_MEMORY} [current_project]
+            set_property XPM_LIBRARIES {XPM_CDC XPM_MEMORY XPM_FIFO} [current_project]
         }
         # TODO: Implement when needed
     }

--- a/build/readme.rst
+++ b/build/readme.rst
@@ -347,6 +347,6 @@ The (incomplete) list of SYNTH_FLAGS array items
 - DEVICE *{ULTRASCALE, VIRTEX7, STRATIX10, AGILEX}*: Sets the FPGA family. In the `comp target`_ is mapped to specific FPGA.
 - FPGA *{xcvu7p-flvb2104-2-i, 1SD280PT2F55E1VG, ...}*: Sets the FPGA part directly.
 - SETUP_FLAGS: List of specific flags for entire project:
-   - USE_XPM_LIBRARIES: includes XPM_CDC XPM_MEMORY in Vivado projects
+   - USE_XPM_LIBRARIES: includes XPM_CDC XPM_MEMORY XPM_FIFO in Vivado projects
 
 For other values and their purpose see the Vivado.inc.tcl or Quartus.inc.tcl file in the build directory.


### PR DESCRIPTION
Adds support for Vivado block designs(.bd) into OFM.

Vivado block designs are useful for quick connection of Vivado IP cores.
I will also add support for model sim, inside simulations they are quite handy to create fast environment for tests. 