### PR TITLE
Fix unexpected outputs of ASYNC_GENERAL

### DIFF
--- a/comp/base/async/general/general_fsm.vhd
+++ b/comp/base/async/general/general_fsm.vhd
@@ -36,6 +36,8 @@ architecture FULL of ASYNC_GENERAL_FSM is
    signal adata_next    : std_logic := '0';
    signal last_adatain  : std_logic := '0';
 
+   signal adatain_masked      : std_logic := '0';
+
    signal comp_last_adatain   : std_logic := '0';
    signal comp_last_adatain2  : std_logic := '0';
    signal comp_adatain        : std_logic := '0';
@@ -104,14 +106,16 @@ begin
       end if;
    end process;
 
+   adatain_masked <= ADATAIN and not ARST;
+
    --! Next State logic
-   next_state_logic: process (present_st, ADATAIN, SIG_AREADY, last_adatain, comp_last_adatain, comp_adatain, comp_last_adatain2, comp_adatain2)
+   next_state_logic: process (present_st, adatain_masked, SIG_AREADY, last_adatain, comp_last_adatain, comp_adatain, comp_last_adatain2, comp_adatain2)
    begin
       case present_st is
 
          --! STATE st0
          when st0 =>
-            if ((last_adatain = comp_last_adatain AND ADATAIN = comp_adatain) OR (last_adatain = comp_last_adatain2 AND ADATAIN = comp_adatain2)) then
+            if ((last_adatain = comp_last_adatain AND adatain_masked = comp_adatain) OR (last_adatain = comp_last_adatain2 AND adatain_masked = comp_adatain2)) then
                next_st <= st1;
             else
                next_st <= st0;
@@ -132,7 +136,7 @@ begin
    end process;
 
    --Output logic
-   output_logic: process (present_st, ADATAIN, sig_adata, last_adatain, comp_last_adatain, comp_adatain, comp_last_adatain2, comp_adatain2)
+   output_logic: process (present_st, adatain_masked, sig_adata, last_adatain, comp_last_adatain, comp_adatain, comp_last_adatain2, comp_adatain2)
    begin
       case present_st is
 
@@ -140,7 +144,7 @@ begin
          when st0 =>
             AREADY <= '1';
 
-            if ((last_adatain = comp_last_adatain AND ADATAIN = comp_adatain) OR (last_adatain = comp_last_adatain2 AND ADATAIN = comp_adatain2)) then
+            if ((last_adatain = comp_last_adatain AND adatain_masked = comp_adatain) OR (last_adatain = comp_last_adatain2 AND adatain_masked = comp_adatain2)) then
                if (sig_adata = '1') then
                   adata_next <= '0';
                else


### PR DESCRIPTION
Hi,

when `ASYNC_GENERAL` (in `base/async/general/`) uses `DETECT_RISING_EDGE = true` and the input is high during reset, an output is incorrectly generated when the reset is deasserted:
![screen](https://github.com/CESNET/ofm/assets/143328395/3e1d9fa5-6104-403c-8064-a1040555754e)

The problem is that while `last_adatain` in `general_fsm.vhd` is being held low during reset, the `next_state_logic` and `output_logic` processes look directly at the `ADATAIN` input. Since last input is forced to '0' and current input is '1', the "rising edge" condition is satisfied and the process sets `adata_next` to '1' (which is then assigned to `sig_adata` after reset ends, and makes its way to the output).

This PR fixes the issue by masking the `ADATAIN` signal during reset, so that it matches the low state of `last_adatain` and therefore avoids triggering the "rising edge" condition by mistake.