### PR TITLE
Fix FL_PIPE REM signal width when DATA_WIDTH is 0 or 8

### DIFF
--- a/comp/fl_tools/flow/pipe/pipe.vhd
+++ b/comp/fl_tools/flow/pipe/pipe.vhd
@@ -12,8 +12,6 @@
 
 library IEEE;
 use IEEE.std_logic_1164.all;
-use IEEE.std_logic_arith.all;
-use IEEE.std_logic_unsigned.all;
 
 use work.math_pack.all;
 
@@ -57,7 +55,7 @@ entity FL_PIPE is
       RX_SRC_RDY_N   : in  std_logic;
       RX_DST_RDY_N   : out std_logic;
       RX_DATA        : in  std_logic_vector(DATA_WIDTH-1 downto 0);
-      RX_REM         : in  std_logic_vector(abs(log2(DATA_WIDTH/8)-1) downto 0);
+      RX_REM         : in  std_logic_vector(tsel(DATA_WIDTH >= 8, log2(DATA_WIDTH/8) -1, -1) downto 0);
  
       -- ================
       -- Output interface
@@ -70,7 +68,7 @@ entity FL_PIPE is
       TX_SRC_RDY_N   : out std_logic;
       TX_DST_RDY_N   : in  std_logic;
       TX_DATA        : out std_logic_vector(DATA_WIDTH-1 downto 0);
-      TX_REM         : out std_logic_vector(abs(log2(DATA_WIDTH/8)-1) downto 0);
+      TX_REM         : out std_logic_vector(tsel(DATA_WIDTH >= 8, log2(DATA_WIDTH/8) -1, -1) downto 0);
          
       -- ==================
       -- Debuging interface
@@ -96,17 +94,8 @@ end entity FL_PIPE;
 -- ----------------------------------------------------------------------------
 architecture fl_pipe_arch of FL_PIPE is
 
-   -- function added by xvozen00 (with change on lines 75 - added 'abs')
-   -- to replace log2(DATA_WIDTH/8) and handle DATA_WIDTH = 8
-   function REM_WIDTH
-      return integer is
-   begin
-      if ((DATA_WIDTH/8) <= 1) then return 2;
-      else return log2(DATA_WIDTH/8);
-      end if;
-   end function;
-
-   constant PIPE_WIDTH        : integer := DATA_WIDTH+REM_WIDTH+4;
+   constant REM_WIDTH         : natural := TX_REM'length;
+   constant PIPE_WIDTH        : natural := DATA_WIDTH + REM_WIDTH + 4;
 
    signal pipe_in_data        : std_logic_vector(PIPE_WIDTH-1 downto 0);
    signal pipe_in_src_rdy     : std_logic;


### PR DESCRIPTION
FL_PIPE has some unexpected behavior with low DATA_WIDTH values:
```
 - for DATA_WIDTH = 32, REM is abs(log2(32 / 8) - 1) = 1 downto 0
 - for DATA_WIDTH = 16, REM is abs(log2(16 / 8) - 1) = 0 downto 0
 - for DATA_WIDTH =  8, REM is abs(log2( 8 / 8) - 1) = 1 downto 0
 - for DATA_WIDTH =  0, REM is abs(log2( 0 / 8) - 1) = ? downto 0
```

For 32 and 16 bits this works correctly. For 8 bits, (1 downto 0) makes no sense, since FL has just one byte that is always valid – it does not need a 2-bit REM. It does not need REM at all. When DATA_WIDTH = 0, the result depends on how systhesis evaluates log2(0); in Vivado it evaluates to 0, so the result is again (1 downto 0).

This proposed fix replaces the bogus ranges for 8 and 0 data widths with null range (-1 downto 0), so that, when not needed, the REM signal becomes zero width and is simply left unused. The REM_WIDTH function previously used to compensate for the weird REM port behavior is replaced by a constant. Unnecessary includes of non-standard numeric packages are also removed.

While Vivado happily ignores null-range signals, I'm not 100% sure if it is acceptable in other toolchains like Modelsim or Quartus. So you may want to test it and consider a different solution if it causes any problems. I suppose that only applies to the DATA_WIDTH = 8 case, since when data width is zero, there are already null ranges in the data ports.